### PR TITLE
Improve publish test readability

### DIFF
--- a/publisher/publisher.go
+++ b/publisher/publisher.go
@@ -342,8 +342,14 @@ func syncDashboardsForStack(stack *grafana.Stack, localFolder, grafanaFolder str
 			// Grafana API will return 404 if 'id' is present, use just uid.
 			delete(dash, "id")
 
+			uid, ok := dash["uid"].(string)
+			if !ok {
+				return fmt.Errorf("dashboard uid %s is not a string in path %s", uid, path)
+			}
+
 			err = sc.UploadDashboard(&grafana.Dashboard{
 				FolderUID: folder.UID,
+				UID:       uid,
 				Dashboard: dash,
 			})
 


### PR DESCRIPTION
When adding features to the publish function, the errors raised
by the current implementation makes it hard to troubleshoot.

```
UploadDashboard(*client.Dashboard)
			0: &client.Dashboard{UID:"", Title:"", FolderUID:"common-folder-uid", Dashboard:map[string]interface {}{"folderUid":"common-folder-uid", "tags":[]interface {}{"tag1", "tag2"}, "title":"Common Dashboard", "uid":"common-dash-uid-suffix"}, Meta:(*models.DashboardMeta)(nil)}

	The closest call I have is:

	UploadDashboard(mock.argumentMatcher)
			0: mock.argumentMatcher{fn:reflect.Value{typ_:(*abi.Type)(0x100df5a80), ptr:(unsafe.Pointer)(0x100f314d8), flag:0x13}}

```

This is particularly true because in this test, we use a mock function to assert on the test expected behaviour.

This commit proposes to change this approach and instead use an assert at the end of the test.
This is expected to provide better error messages to debug tests and implementations

Resulting assertions:

```console
                Error:          Not equal:
                                expected: map[string]*client.Dashboard{"common-dash-uid":(*client.Dashboard)(0x140003be4b0), "custom-dash-uid":(*client.Dashboard)(0x140003be500)}
                                actual  : map[string]*client.Dashboard{"common-dash-uid":(*client.Dashboard)(0x140003be280), "custom-dash-uid":(*client.Dashboard)(0x140003be140)}

                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -2,3 +2,3 @@
                                  (string) (len=15) "common-dash-uid": (*client.Dashboard)({
                                -  UID: (string) "",
                                +  UID: (string) (len=15) "common-dash-uid",
                                   Title: (string) "",
                                @@ -13,3 +13,3 @@
                                  (string) (len=15) "custom-dash-uid": (*client.Dashboard)({
                                -  UID: (string) "",
                                +  UID: (string) (len=15) "custom-dash-uid",
                                   Title: (string) "",
```
<details>
<summary>
Committer details
</summary>
Local-Branch: main
</details>
<details>
<summary>
Related changes
</summary>
<details>
<summary>
Future changes
</summary>
<details>
<summary>
Allow grafana client to create hierarchical folders (#9)
</summary>
For testing purposes we want to be able to create dashboards in
subfolders.

For example, creating the structure within `pr/my-repo/pulls/1234`

This PR adds the ability to create this hierarchy
</details>
<details>
<summary>
Add support for multiple test dashboards at once (#10)
</summary>
When creating multiple pull requests at the same time
to change dashboards, add the ability to:
- store them in a dedicated subfolder like `pr/number`
- provide a unique dashboard ID to avoid collision with "production" dashboards
- add specific tags to better identify and find the dashboards
</details>
</details>
</details>