### PR TITLE
Add verbosity to EnsureFolder

### DIFF
--- a/publisher/go.mod
+++ b/publisher/go.mod
@@ -3,7 +3,7 @@ module github.com/adevinta/go-grafana-toolkit/publisher
 go 1.23.4
 
 require (
-	github.com/adevinta/go-grafana-toolkit/client v0.0.0-20250806121714-1694abd0149f
+	github.com/adevinta/go-grafana-toolkit/client v0.0.0-20250806153515-1246658ff546
 	github.com/adevinta/go-log-toolkit v0.0.0-20241010122356-50ef5e036d19
 	github.com/adevinta/go-system-toolkit v0.0.0-20240912143443-133d8c380cfc
 	github.com/adevinta/go-testutils-toolkit v0.0.0-20240913074508-af35ec32d0a7

--- a/publisher/go.sum
+++ b/publisher/go.sum
@@ -1,5 +1,7 @@
 github.com/adevinta/go-grafana-toolkit/client v0.0.0-20250806121714-1694abd0149f h1:Q+4xJpi7aaqun60Y2Aio1bZboipt4Ny2EkB75spQLkA=
 github.com/adevinta/go-grafana-toolkit/client v0.0.0-20250806121714-1694abd0149f/go.mod h1:1vDDJ28WqUEqtlJxx/4QOtDvuW7z3N6SskHrY0+I2h0=
+github.com/adevinta/go-grafana-toolkit/client v0.0.0-20250806153515-1246658ff546 h1:bcqweSeAL1SMBqt+Tlhcx1a1RFkYLyb+KChLTz0zdBo=
+github.com/adevinta/go-grafana-toolkit/client v0.0.0-20250806153515-1246658ff546/go.mod h1:1vDDJ28WqUEqtlJxx/4QOtDvuW7z3N6SskHrY0+I2h0=
 github.com/adevinta/go-log-toolkit v0.0.0-20241010122356-50ef5e036d19 h1:oLWqBNiMCds/hsWjHGYgceUzYfJquhQoHEmSEdq0gKM=
 github.com/adevinta/go-log-toolkit v0.0.0-20241010122356-50ef5e036d19/go.mod h1:oKcFLGHSHtWJRos+gkZ/tji5U4v6f+f8DMRP+91G+Yg=
 github.com/adevinta/go-system-toolkit v0.0.0-20240912143443-133d8c380cfc h1:AjWBRPpsZRIubsXViIgTPdGRF1qPTGMg5/zKzfu7xgQ=


### PR DESCRIPTION
Currently, we face a problem where folders may be re-created

Adding the verbosity helps understand in which conditions they get re-created
<details>
<summary>
Committer details
</summary>
Local-Branch: main
</details>
<details>
<summary>
Related changes
</summary>
<details>
<summary>
Future changes
</summary>
<details>
<summary>
wait for folder to be returned by the API in EnsureFolder
</summary>
We are observing that from time to time,
thGetFolder fails to find folders that has just been created.
This leads to duplicate folders in Grafana Cloud.

To solve this, implement a polling mechanism to wait for the folder to be fully created and returned by the API
</details>
</details>
</details>