### PR TITLE
Add verbosity to EnsureFolder

### DIFF
--- a/client/dashboard.go
+++ b/client/dashboard.go
@@ -159,6 +159,7 @@ func (sc *StackClient) GetFolder(rootFolder *Folder, folderName string) (*Folder
 	for _, f := range foldersRes.Payload {
 		log.DefaultLogger.WithField("folder", f.Title).WithField("searched", folderName).Tracef("matching folder")
 		if f.Title == folderName {
+			log.DefaultLogger.WithField("folder", f.Title).WithField("searched", folderName).Tracef("found folder")
 			return &Folder{
 				UID:   f.UID,
 				Title: f.Title,
@@ -179,7 +180,7 @@ func (sc *StackClient) EnsureFolder(rootFolder *Folder, folderName string) (*Fol
 		return nil, fmt.Errorf("failed to get folders for %s: %w", folderName, err)
 	}
 
-	log.DefaultLogger.WithField("folder", folder). WithField("searched", folderName). Tracef("found folder")
+	log.DefaultLogger.WithField("folder", folder).WithField("searched", folderName).Tracef("found folder")
 
 	if folder != nil {
 		return folder, nil


### PR DESCRIPTION
Currently, we face a problem where folders may be re-created

Adding the verbosity helps understand in which conditions they get re-created
<details>
<summary>
Committer details
</summary>
Local-Branch: main
</details>
<details>
<summary>
Related changes
</summary>
<details>
<summary>
Future changes
</summary>
<details>
<summary>
wait for folder to be returned by the API in EnsureFolder
</summary>
We are observing that from time to time,
thGetFolder fails to find folders that has just been created.
This leads to duplicate folders in Grafana Cloud.

To solve this, implement a polling mechanism to wait for the folder to be fully created and returned by the API
</details>
<details>
<summary>
Create parent folders once for all stacks and syncs
</summary>
There is an eventual consistency behaviour in how grafana
handles and creates dashboard folders. In particular for "top level folders"
This is problematic as it leads to, sometimes, duplicating the toplevel folders
in particular when there are multiple synchronised folders.

To work-around this, create the parent folder once for all in all stacks
at the begining of the Publishing
</details>
</details>
</details>